### PR TITLE
Crash fix: GetTranslation crash and modsDirPath crash

### DIFF
--- a/ConsoleAdventure/CaModLoader.cs
+++ b/ConsoleAdventure/CaModLoader.cs
@@ -246,6 +246,8 @@ namespace ConsoleAdventure
         {
             string enabledModsFile = modsDirPath + @"\enabled-mods.json";
 
+            Directory.CreateDirectory(modsDirPath);
+
             if (!File.Exists(enabledModsFile))
             {
                 string data = JsonSerializer.Serialize(new List<string>());

--- a/ConsoleAdventure/ConsoleAdventure.cs
+++ b/ConsoleAdventure/ConsoleAdventure.cs
@@ -134,6 +134,8 @@ namespace ConsoleAdventure
             if (File.Exists(Program.savePath + "settings.json")) // Если файл существует
                 SettingsSystem.LoadSettings(); // Загружаем сохраненные настройки
 
+            SettingsSystem.InitOptionDefaultSettings();
+
             InputConfig.Init();
             InputConfig.Load();
 

--- a/ConsoleAdventure/Content/Scripts/SettingsSystem.cs
+++ b/ConsoleAdventure/Content/Scripts/SettingsSystem.cs
@@ -24,6 +24,12 @@ namespace ConsoleAdventure
                 
         }
 
+        public static void InitOptionDefaultSettings()
+        {
+            InitSetting("Options", "Language", (int)Language.english);
+            InitSetting("Options", "MusicVolume", 100);
+        }
+
         public static void SetSetting(string type, string key, int value)
         {
             settings[type][key] = value; // По типу и ключу установить значение


### PR DESCRIPTION
## Что исправлено

- Добавлена инициализация дефолтных настроек при старте игры.
- Теперь недостающие значения `Options`, включая `Language` и `MusicVolume`, создаются до использования локализации и аудио.
- Исправлен краш при запуске, когда `TextAssets` обращался к локализации без сохраненной настройки языка.

Я уже как-то давно контрибьютил сюда только с другого аккаунта, чисто стилистическое что-то делал (Code-style роде). Я так понимаю такие проблемы с крашами могли испытывать все кто бы клонил чистый репозиторий без билдов.